### PR TITLE
HostUrl.cdn_host contains full URL. Parsing and taking  URI.host

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1324,7 +1324,7 @@ class User < ActiveRecord::Base
     if fallback and uri = URI.parse(fallback) rescue nil
       uri.scheme ||= request ? request.protocol[0..-4] : HostUrl.protocol # -4 to chop off the ://
       if HostUrl.cdn_host
-        uri.host = HostUrl.cdn_host
+        uri.host = URI.parse(HostUrl.cdn_host).host
       elsif request && !uri.host
         uri.host = request.host
         uri.port = request.port if ![80, 443].include?(request.port)


### PR DESCRIPTION
HostUrl.cdn_host contains full URL. Parsing and taking  URI.host.

When It assign uri.host, Ruby raise a exception:

URI::InvalidComponentError (bad component(expected host component): https://xxxxxxxxxx.cloudfront.net):
  /usr/lib/ruby/2.1.0/uri/generic.rb:605:in `check_host'
  /usr/lib/ruby/2.1.0/uri/generic.rb:646:in `host='
  /var/canvas/app/models/user.rb:1319:in `avatar_fallback_url'
  /var/canvas/app/helpers/avatar_helper.rb:77:in `avatar_url_for_user'
  /var/canvas/lib/api/v1/user.rb:73:in `block in user_json'
  /var/canvas/lib/api/v1/user.rb:48:in `tap'
  /var/canvas/lib/api/v1/user.rb:48:in `user_json'
  /var/canvas/app/controllers/users_controller.rb:1053:in `api_show'